### PR TITLE
fix: fixed import for typebox and updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ junit.xml
 cypress/screenshots
 script.ts
 .wrangler
+test-dashboard.md

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 import { Octokit } from "@octokit/rest";
-import { Value } from "@sinclair/typebox/build/cjs/value";
+import { Value } from "@sinclair/typebox/value";
 import { envSchema, pluginSettingsSchema, PluginInputs, pluginSettingsValidator } from "./types";
 import { plugin } from "./plugin";
 


### PR DESCRIPTION
The imports were wrong for TypeBox and causing a crash at runtime.