### PR TITLE
feat: only the global name is considered for automatic deployment

### DIFF
--- a/.github/workflows/worker-delete.yml
+++ b/.github/workflows/worker-delete.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Retrieve and Construct Full Worker Name
         id: construct_worker_name
         run: |
-          base_name=$(grep '^name = ' wrangler.toml | sed 's/^name = "\(.*\)"$/\1/')
+          base_name=$(grep '^name = ' wrangler.toml | head -n 1 | sed 's/^name = "\(.*\)"$/\1/')
           full_worker_name="${base_name}-${{ env.branch_name }}"
           # Make sure that it doesnt exceed 63 characters or it will break RFC 1035
           full_worker_name=$(echo "${full_worker_name}" | cut -c 1-63)

--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -23,19 +23,18 @@ jobs:
         run: |
           branch_name=$(echo '${{ github.event.ref }}' | sed 's#refs/heads/##' | sed 's#[^a-zA-Z0-9]#-#g')
           # Extract base name from wrangler.toml
-          base_name=$(grep '^name = ' wrangler.toml | sed 's/^name = "\(.*\)"$/\1/')
+          base_name=$(grep '^name = ' wrangler.toml | head -n 1 | sed 's/^name = "\(.*\)"$/\1/')
           # Concatenate branch name with base name
           new_name="${base_name}-${branch_name}"
           # Truncate the new name to 63 characters for RFC 1035
           new_name=$(echo "$new_name" | cut -c 1-63)
           # Update the wrangler.toml file
-          sed -i "s/^name = .*/name = \"$new_name\"/" wrangler.toml
+          sed -i '0,/^name = .*/{s/^name = .*/name = "'"$new_name"'"/}' wrangler.toml
           echo "Updated wrangler.toml name to: $new_name"
       - name: Deploy with Wrangler
         id: wrangler_deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          wranglerVersion: "3.57.0"
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           secrets: |


### PR DESCRIPTION
Resolves #18 

QA:
- [deploy](https://github.com/Meniole/command-query-user/actions/runs/11007080274)
- [delete](https://github.com/Meniole/command-query-user/actions/runs/11007092651)

A `toml` file cannot redefine a value from the global space, so the global value will always come at the top of the file so it's safe to regex and extract the first match (otherwise toml yields `Error: Can't redefine existing key`). If no global name value is defined, wrangler will complain saying `✘ [ERROR] You need to provide a name when publishing a worker. Either pass it as a cli arg with --name <name> or in your config file as name = "<name>"`, which forces the value on the global space.

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
