### PR TITLE
perf: setting up bun is unnecessary

### DIFF
--- a/.github/workflows/compute.yml
+++ b/.github/workflows/compute.yml
@@ -37,10 +37,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
       - name: execute directive
-        run: bun ./dist/index.js
-        id: plugin-name
+        run: node ./dist/index.js


### PR DESCRIPTION
Resolves #50 

I didn't test this because I'm not 100% of the syntax, but look how GitHub made their example for instant cold starts.

https://github.com/actions/typescript-action/blob/main/action.yml#L22-L24
