### PR TITLE
feat: Reusable Knip and Jest Workflows - Bounty #13 ($1200)

### DIFF
--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -2,6 +2,28 @@ name: Run Jest testing suite
 on:
   workflow_dispatch:
   pull_request:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node.js version"
+        required: false
+        default: "20"
+        type: string
+      package-manager:
+        description: "Package manager (bun, yarn, npm)"
+        required: false
+        default: "bun"
+        type: string
+      working-directory:
+        description: "Working directory"
+        required: false
+        default: "."
+        type: string
+      test-command:
+        description: "Custom test command (overrides default)"
+        required: false
+        default: ""
+        type: string
 
 env:
   NODE_ENV: "test"
@@ -11,19 +33,59 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun
+        if: inputs.package-manager == 'bun' || (inputs.package-manager == '' && github.event_name != 'workflow_call')
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Setup Node
+        if: inputs.package-manager != 'bun' && inputs.package-manager != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager == 'yarn' && 'yarn' || inputs.package-manager == 'npm' && 'npm' || '' }}
 
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Jest With Coverage
-        run: |
-          bun install --frozen-lockfile
-          bun run test
+      - name: Install dependencies (bun)
+        if: inputs.package-manager == 'bun' || (inputs.package-manager == '' && github.event_name != 'workflow_call')
+        working-directory: ${{ inputs.working-directory }}
+        run: bun install --frozen-lockfile
+
+      - name: Install dependencies (npm)
+        if: inputs.package-manager == 'npm'
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Install dependencies (yarn)
+        if: inputs.package-manager == 'yarn'
+        working-directory: ${{ inputs.working-directory }}
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests (custom command)
+        if: inputs.test-command != ''
+        working-directory: ${{ inputs.working-directory }}
+        run: ${{ inputs.test-command }}
+
+      - name: Run tests (bun)
+        if: inputs.test-command == '' && (inputs.package-manager == 'bun' || (inputs.package-manager == '' && github.event_name != 'workflow_call'))
+        working-directory: ${{ inputs.working-directory }}
+        run: bun run test
+
+      - name: Run tests (npm)
+        if: inputs.test-command == '' && inputs.package-manager == 'npm'
+        working-directory: ${{ inputs.working-directory }}
+        run: npm test
+
+      - name: Run tests (yarn)
+        if: inputs.test-command == '' && inputs.package-manager == 'yarn'
+        working-directory: ${{ inputs.working-directory }}
+        run: yarn test
 
       - name: Add Jest Report to Summary
         if: always()
+        working-directory: ${{ inputs.working-directory }}
         run: echo "$(cat test-dashboard.md)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -3,6 +3,23 @@ name: Knip
 on:
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node.js version"
+        required: false
+        default: "20"
+        type: string
+      package-manager:
+        description: "Package manager (bun, yarn, npm)"
+        required: false
+        default: "bun"
+        type: string
+      working-directory:
+        description: "Working directory"
+        required: false
+        default: "."
+        type: string
 
 jobs:
   run-knip:
@@ -12,16 +29,45 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Bun
+        if: inputs.package-manager == 'bun' || (inputs.package-manager == '' && github.event_name != 'workflow_call')
         uses: oven-sh/setup-bun@v2
 
-      - name: Install toolchain
+      - name: Setup Node
+        if: inputs.package-manager != 'bun'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager == 'yarn' && 'yarn' || inputs.package-manager == 'npm' && 'npm' || '' }}
+
+      - name: Install toolchain (bun)
+        if: inputs.package-manager == 'bun' || (inputs.package-manager == '' && github.event_name != 'workflow_call')
+        working-directory: ${{ inputs.working-directory }}
         run: bun install
 
+      - name: Install toolchain (npm)
+        if: inputs.package-manager == 'npm'
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Install toolchain (yarn)
+        if: inputs.package-manager == 'yarn'
+        working-directory: ${{ inputs.working-directory }}
+        run: yarn install --frozen-lockfile
+
       - name: Store PR number
+        if: github.event_name == 'pull_request'
         run: echo ${{ github.event.number }} > pr-number.txt
 
       - name: Run Knip
-        run: bun run knip || bun run knip --reporter json > knip-results.json
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ "${{ inputs.package-manager }}" = "bun" ] || [ "${{ inputs.package-manager }}" = "" ]; then
+            bun run knip || bun run knip --reporter json > knip-results.json
+          elif [ "${{ inputs.package-manager }}" = "yarn" ]; then
+            yarn knip || yarn knip --reporter json > knip-results.json
+          else
+            npm run knip || npm run knip -- --reporter json > knip-results.json
+          fi
 
       - name: Upload knip result
         if: failure()

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ GitHub Action Secrets.
 - [Full Ubiquibot Configuration](https://github.com/ubiquity/ubiquibot/blob/0fde7551585499b1e0618ec8ea5e826f11271c9c/src/types/configuration-types.ts#L62) - helpful for defining your plugin's settings as they are strongly typed and will be validated by the kernel.
 - [Ubiquibot V1](https://github.com/ubiquity/ubiquibot) - helpful for porting V1 functionality to V2, helper/utility functions, types, etc. Everything is based on the V1 codebase but with a more modular approach. When using V1 code, keep in mind that most all code will need refactored to work with the new V2 architecture.
 
+## Reusable Workflows
+
+This template provides reusable GitHub Actions workflows for **Knip** (unused code detection) and **Jest** (testing) that any repository can call via `workflow_call`.
+
+```yaml
+jobs:
+  knip:
+    uses: ubiquity-os/plugin-template/.github/workflows/knip.yml@main
+  test:
+    uses: ubiquity-os/plugin-template/.github/workflows/jest-testing.yml@main
+```
+
+Both workflows support configurable `node-version`, `package-manager` (`bun`/`yarn`/`npm`), and `working-directory`. See [docs/reusable-workflows.md](./docs/reusable-workflows.md) for full documentation.
+
 ## Examples
 
 - [Start/Stop Slash Command](https://github.com/ubq-testing/start-stop-module) - simple

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -1,0 +1,101 @@
+# Reusable Workflows
+
+This repository provides reusable GitHub Actions workflows for Knip (unused code detection) and Jest (testing) that can be called from any repository in the `ubiquity-os` organization (or beyond).
+
+## Available Workflows
+
+### Knip — `.github/workflows/knip.yml`
+
+Runs [Knip](https://github.com/webpro/knip) to detect unused files, dependencies, exports, and more.
+
+**Inputs:**
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `node-version` | Node.js version | `20` | No |
+| `package-manager` | Package manager: `bun`, `yarn`, or `npm` | `bun` | No |
+| `working-directory` | Working directory for commands | `.` | No |
+
+### Jest — `.github/workflows/jest-testing.yml`
+
+Runs the Jest test suite with coverage reporting.
+
+**Inputs:**
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `node-version` | Node.js version | `20` | No |
+| `package-manager` | Package manager: `bun`, `yarn`, or `npm` | `bun` | No |
+| `working-directory` | Working directory for commands | `.` | No |
+| `test-command` | Custom test command (overrides default) | `""` | No |
+
+## Usage
+
+### Minimal (defaults)
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  knip:
+    uses: ubiquity-os/plugin-template/.github/workflows/knip.yml@main
+
+  test:
+    uses: ubiquity-os/plugin-template/.github/workflows/jest-testing.yml@main
+```
+
+### With custom package manager
+
+```yaml
+jobs:
+  knip:
+    uses: ubiquity-os/plugin-template/.github/workflows/knip.yml@main
+    with:
+      package-manager: yarn
+
+  test:
+    uses: ubiquity-os/plugin-template/.github/workflows/jest-testing.yml@main
+    with:
+      package-manager: npm
+```
+
+### With custom test command and working directory
+
+```yaml
+jobs:
+  test:
+    uses: ubiquity-os/plugin-template/.github/workflows/jest-testing.yml@main
+    with:
+      package-manager: bun
+      working-directory: ./packages/my-package
+      test-command: "bun run test:ci"
+```
+
+### Full configuration
+
+```yaml
+jobs:
+  knip:
+    uses: ubiquity-os/plugin-template/.github/workflows/knip.yml@main
+    with:
+      node-version: "22"
+      package-manager: yarn
+      working-directory: ./src
+
+  test:
+    uses: ubiquity-os/plugin-template/.github/workflows/jest-testing.yml@main
+    with:
+      node-version: "22"
+      package-manager: yarn
+      working-directory: ./src
+      test-command: "yarn test:coverage"
+```
+
+## Notes
+
+- The workflows still work standalone (direct triggers via `pull_request` and `workflow_dispatch`) as well as via `workflow_call`.
+- The Knip reporter workflow (`knip-reporter.yml`) remains unchanged and will continue to post comments on PRs when Knip detects issues.
+- Pin to a specific ref (tag or commit SHA) instead of `main` for production stability.


### PR DESCRIPTION
## Reusable Knip and Jest Workflows

Bounty: #13 | Reward: $1200

### Changes
- Converted Knip workflow to reusable (`workflow_call`)
- Converted Jest workflow to reusable (`workflow_call`)
- Configurable: `node-version`, `package-manager`, `working-directory`
- Supports bun, yarn, npm package managers
- Full documentation for consumers in `docs/reusable-workflows.md`
- Updated README with reusable workflows section

### Usage from other repos
```yaml
jobs:
  knip:
    uses: ubiquity-os/plugin-template/.github/workflows/knip.yml@main
  test:
    uses: ubiquity-os/plugin-template/.github/workflows/jest-testing.yml@main
    with:
      package-manager: yarn
```

### Files changed
- `.github/workflows/knip.yml` — Added `workflow_call` trigger with inputs
- `.github/workflows/jest-testing.yml` — Added `workflow_call` trigger with inputs
- `docs/reusable-workflows.md` — New documentation
- `README.md` — Added reusable workflows section