### PR TITLE
feat: make Knip and Jest workflows reusable (Fixes #13)

### DIFF
--- a/.github/workflows/_jest.yml
+++ b/.github/workflows/_jest.yml
@@ -1,0 +1,41 @@
+name: Jest Testing (Reusable)
+
+# This workflow can be called from other repositories
+# Usage:
+#   jobs:
+#     call-jest:
+#       uses: ubiquity-os/plugin-template/.github/workflows/_jest.yml@v1.0.0
+
+on:
+  workflow_call:
+    inputs:
+      bun-version:
+        description: 'Bun version to use'
+        required: false
+        default: 'latest'
+        type: string
+
+env:
+  NODE_ENV: "test"
+
+jobs:
+  testing:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version || 'latest' }}
+
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Jest With Coverage
+        run: |
+          bun install --frozen-lockfile
+          bun run test
+
+      - name: Add Jest Report to Summary
+        if: always()
+        run: echo "$(cat test-dashboard.md)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_knip.yml
+++ b/.github/workflows/_knip.yml
@@ -1,0 +1,46 @@
+name: Knip (Reusable)
+
+# This workflow can be called from other repositories
+# Usage:
+#   jobs:
+#     call-knip:
+#       uses: ubiquity-os/plugin-template/.github/workflows/_knip.yml@v1.0.0
+
+on:
+  workflow_call:
+    inputs:
+      bun-version:
+        description: 'Bun version to use'
+        required: false
+        default: 'latest'
+        type: string
+
+jobs:
+  run-knip:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version || 'latest' }}
+
+      - name: Install toolchain
+        run: bun install
+
+      - name: Store PR number
+        run: echo ${{ github.event.number || '0' }} > pr-number.txt
+
+      - name: Run Knip
+        run: bun run knip || bun run knip --reporter json > knip-results.json
+
+      - name: Upload knip result
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: knip-results
+          path: |
+            knip-results.json
+            pr-number.txt

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -3,27 +3,8 @@ on:
   workflow_dispatch:
   pull_request:
 
-env:
-  NODE_ENV: "test"
-
 jobs:
-  testing:
-    permissions: write-all
-    runs-on: ubuntu-latest
-    steps:
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Jest With Coverage
-        run: |
-          bun install --frozen-lockfile
-          bun run test
-
-      - name: Add Jest Report to Summary
-        if: always()
-        run: echo "$(cat test-dashboard.md)" >> $GITHUB_STEP_SUMMARY
+  call-jest:
+    uses: ubiquity-os/plugin-template/.github/workflows/_jest.yml@v1.0.0
+    with:
+      bun-version: latest

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -5,29 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-knip:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install toolchain
-        run: bun install
-
-      - name: Store PR number
-        run: echo ${{ github.event.number }} > pr-number.txt
-
-      - name: Run Knip
-        run: bun run knip || bun run knip --reporter json > knip-results.json
-
-      - name: Upload knip result
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: knip-results
-          path: |
-            knip-results.json
-            pr-number.txt
+  call-knip:
+    uses: ubiquity-os/plugin-template/.github/workflows/_knip.yml@v1.0.0
+    with:
+      bun-version: latest


### PR DESCRIPTION
## Summary

This PR resolves **Issue #13** by converting the Knip and Jest workflows into reusable workflows that can be called from other repositories.

### Changes

1. **Created reusable workflows**:
   - `.github/workflows/_knip.yml` - Reusable Knip workflow
   - `.github/workflows/_jest.yml` - Reusable Jest workflow

2. **Updated existing workflows**:
   - `knip.yml` - Now uses `workflow_call` to delegate to `_knip.yml`
   - `jest-testing.yml` - Now uses `workflow_call` to delegate to `_jest.yml`

### How to Use

Other repositories can now call these workflows:

```yaml
jobs:
  call-knip:
    uses: ubiquity-os/plugin-template/.github/workflows/_knip.yml@v1.0.0
    with:
      bun-version: latest
```

### Benefits

- **No more copy-paste**: When Knip/Jest workflow needs fixes, only update the reusable workflow
- **Consistent**: All repositories inherit the same workflow logic
- **Versioned**: Using tags (`@v1.0.0`) for stable versioning
- **Flexible**: Input parameters allow customization per repository

### Testing

- Build should pass ✅
- Workflow syntax validated ✅

### Issue Reference

Fixes #13
