### PR TITLE
Make Knip and Jest workflows reusable

### DIFF
--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -1,7 +1,50 @@
 name: Run Jest testing suite
+
 on:
   workflow_dispatch:
   pull_request:
+  workflow_call:
+    inputs:
+      package_manager:
+        description: Package manager used to install dependencies and run tests.
+        required: false
+        type: string
+        default: bun
+      bun_version:
+        description: Bun version to install when package_manager is bun.
+        required: false
+        type: string
+        default: latest
+      node_version:
+        description: Node.js version to install when package_manager is yarn.
+        required: false
+        type: string
+        default: 24
+      yarn_version:
+        description: Optional Yarn version to activate with Corepack when package_manager is yarn.
+        required: false
+        type: string
+        default: ""
+      install_command:
+        description: Override dependency installation command.
+        required: false
+        type: string
+        default: ""
+      test_command:
+        description: Override Jest/test command.
+        required: false
+        type: string
+        default: ""
+      summary_file:
+        description: Markdown file to append to the GitHub step summary when it exists.
+        required: false
+        type: string
+        default: test-dashboard.md
+      fetch_depth:
+        description: Checkout fetch depth.
+        required: false
+        type: number
+        default: 0
 
 env:
   NODE_ENV: "test"
@@ -11,19 +54,52 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun
+        if: ${{ inputs.package_manager == '' || inputs.package_manager == 'bun' }}
+        uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ inputs.bun_version || 'latest' }}
+
+      - name: Setup Node for Yarn
+        if: ${{ inputs.package_manager == 'yarn' }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ inputs.node_version || '24' }}
+          cache: yarn
+
+      - name: Enable requested Yarn version
+        if: ${{ inputs.package_manager == 'yarn' && inputs.yarn_version != '' }}
+        run: |
+          corepack enable
+          corepack prepare yarn@${{ inputs.yarn_version }} --activate
 
       - uses: actions/checkout@v5
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch_depth || 0 }}
 
       - name: Jest With Coverage
+        shell: bash
         run: |
-          bun install --frozen-lockfile
-          bun run test
+          if [ -n "${{ inputs.install_command }}" ]; then
+            ${{ inputs.install_command }}
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn install --immutable
+          else
+            bun install --frozen-lockfile
+          fi
+
+          if [ -n "${{ inputs.test_command }}" ]; then
+            ${{ inputs.test_command }}
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn test
+          else
+            bun run test
+          fi
 
       - name: Add Jest Report to Summary
         if: always()
-        run: echo "$(cat test-dashboard.md)" >> $GITHUB_STEP_SUMMARY
+        shell: bash
+        run: |
+          if [ -f "${{ inputs.summary_file }}" ]; then
+            cat "${{ inputs.summary_file }}" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/knip-reporter.yml
+++ b/.github/workflows/knip-reporter.yml
@@ -5,36 +5,78 @@ on:
     workflows: ["Knip"]
     types:
       - completed
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: Name of the Knip results artifact to download.
+        required: false
+        type: string
+        default: knip-results
+      run_id:
+        description: Workflow run id that produced the Knip results artifact. Defaults to the current run when omitted.
+        required: false
+        type: string
+        default: ""
+      pull_request_number:
+        description: Pull request number to comment on. If omitted, the workflow reads pr-number.txt from the artifact.
+        required: false
+        type: string
+        default: ""
+      comment_id:
+        description: Sticky comment id used by ubiquity/knip-reporter.
+        required: false
+        type: string
+        default: Knip-reporter-reporter
+      command_script_name:
+        description: Command name displayed by ubiquity/knip-reporter.
+        required: false
+        type: string
+        default: knip-ci
+    secrets:
+      token:
+        description: GitHub token with permission to read artifacts and comment on pull requests.
+        required: false
 
 permissions: write-all
 
 jobs:
   knip-reporter:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion != 'success' }}
+    if: ${{ github.event_name == 'workflow_call' || github.event.workflow_run.conclusion != 'success' }}
     steps:
       - uses: actions/download-artifact@v6
         with:
-          name: knip-results
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ inputs.artifact_name || 'knip-results' }}
+          run-id: ${{ inputs.run_id || github.event.workflow_run.id || github.run_id }}
+          github-token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
 
-      - name: Read pr number
+      - name: Read PR number from artifact
+        if: ${{ inputs.pull_request_number == '' }}
         id: pr-number
         uses: juliangruber/read-file-action@v1
         with:
           path: ./pr-number.txt
           trim: true
 
+      - name: Resolve pull request number
+        id: pull-request-number
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.pull_request_number }}" ]; then
+            echo "number=${{ inputs.pull_request_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ steps.pr-number.outputs.content }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Report knip results to pull request
         uses: ubiquity/knip-reporter@main
         with:
           verbose: true
-          comment_id: ${{ github.workflow }}-reporter
-          command_script_name: knip-ci
+          comment_id: ${{ inputs.comment_id || 'Knip-reporter-reporter' }}
+          command_script_name: ${{ inputs.command_script_name || 'knip-ci' }}
           annotations: true
           ignore_results: false
           json_input: true
           json_input_file_name: knip-results.json
-          pull_request_number: ${{ steps.pr-number.outputs.content }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          pull_request_number: ${{ steps.pull-request-number.outputs.number }}
+          token: ${{ secrets.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -3,6 +3,48 @@ name: Knip
 on:
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      package_manager:
+        description: Package manager used to install dependencies and run Knip.
+        required: false
+        type: string
+        default: bun
+      bun_version:
+        description: Bun version to install when package_manager is bun.
+        required: false
+        type: string
+        default: latest
+      node_version:
+        description: Node.js version to install when package_manager is yarn.
+        required: false
+        type: string
+        default: 24
+      yarn_version:
+        description: Optional Yarn version to activate with Corepack when package_manager is yarn.
+        required: false
+        type: string
+        default: ""
+      install_command:
+        description: Override dependency installation command.
+        required: false
+        type: string
+        default: ""
+      knip_command:
+        description: Command that runs Knip in normal human-readable mode.
+        required: false
+        type: string
+        default: ""
+      knip_json_command:
+        description: Command that writes JSON Knip results to knip-results.json without failing the shell before redirection.
+        required: false
+        type: string
+        default: ""
+      artifact_name:
+        description: Artifact name used by the reporter workflow.
+        required: false
+        type: string
+        default: knip-results
 
 jobs:
   run-knip:
@@ -12,22 +54,68 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Bun
+        if: ${{ inputs.package_manager == '' || inputs.package_manager == 'bun' }}
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun_version || 'latest' }}
+
+      - name: Setup Node for Yarn
+        if: ${{ inputs.package_manager == 'yarn' }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ inputs.node_version || '24' }}
+          cache: yarn
+
+      - name: Enable requested Yarn version
+        if: ${{ inputs.package_manager == 'yarn' && inputs.yarn_version != '' }}
+        run: |
+          corepack enable
+          corepack prepare yarn@${{ inputs.yarn_version }} --activate
 
       - name: Install toolchain
-        run: bun install
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.install_command }}" ]; then
+            ${{ inputs.install_command }}
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn install --immutable
+          else
+            bun install
+          fi
 
       - name: Store PR number
+        if: ${{ github.event_name == 'pull_request' }}
         run: echo ${{ github.event.number }} > pr-number.txt
 
       - name: Run Knip
-        run: bun run knip || bun run knip --reporter json > knip-results.json
+        shell: bash
+        run: |
+          KNIP_COMMAND="${{ inputs.knip_command }}"
+          KNIP_JSON_COMMAND="${{ inputs.knip_json_command }}"
+
+          if [ -z "$KNIP_COMMAND" ]; then
+            if [ "${{ inputs.package_manager }}" = "yarn" ]; then
+              KNIP_COMMAND="yarn knip"
+            else
+              KNIP_COMMAND="bun run knip"
+            fi
+          fi
+
+          if [ -z "$KNIP_JSON_COMMAND" ]; then
+            if [ "${{ inputs.package_manager }}" = "yarn" ]; then
+              KNIP_JSON_COMMAND="yarn knip --reporter json"
+            else
+              KNIP_JSON_COMMAND="bun run knip --reporter json"
+            fi
+          fi
+
+          $KNIP_COMMAND || $KNIP_JSON_COMMAND > knip-results.json
 
       - name: Upload knip result
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: knip-results
+          name: ${{ inputs.artifact_name || 'knip-results' }}
           path: |
             knip-results.json
             pr-number.txt

--- a/README.md
+++ b/README.md
@@ -39,6 +39,77 @@ plugins:
 
 6. Start building your plugin by adding your logic to the [plugin.ts](./src/index.ts) file.
 
+## Reusable CI workflows
+
+This template exposes the Knip and Jest checks as reusable GitHub Actions workflows so fixes can be propagated to repositories that inherited from the template without copying workflow internals into every repository.
+
+### Reuse Knip
+
+```yml
+name: Knip
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  knip:
+    uses: ubiquity-os/plugin-template/.github/workflows/knip.yml@main
+    with:
+      package_manager: bun # or yarn
+```
+
+For Yarn-based repositories, pass the package manager and, when needed, the Yarn version:
+
+```yml
+jobs:
+  knip:
+    uses: ubiquity-os/plugin-template/.github/workflows/knip.yml@main
+    with:
+      package_manager: yarn
+      yarn_version: 4.9.2
+```
+
+If a child repository has custom scripts, override the commands instead of forking the workflow:
+
+```yml
+with:
+  install_command: yarn install --immutable
+  knip_command: yarn knip
+  knip_json_command: yarn knip --reporter json
+```
+
+### Reuse Knip reporter
+
+The default `knip-reporter.yml` still listens for this repository's `Knip` workflow via `workflow_run`. Repositories that want a thin local reporter can call the reusable reporter and pass the producing run id and pull request number:
+
+```yml
+jobs:
+  report:
+    uses: ubiquity-os/plugin-template/.github/workflows/knip-reporter.yml@main
+    with:
+      run_id: ${{ github.event.workflow_run.id }}
+      pull_request_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+```
+
+### Reuse Jest
+
+```yml
+name: Run Jest testing suite
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  testing:
+    uses: ubiquity-os/plugin-template/.github/workflows/jest-testing.yml@main
+    with:
+      package_manager: bun # or yarn
+```
+
+Override `install_command`, `test_command`, `summary_file`, or package-manager versions when a repository differs from the template defaults.
+
 ## Testing a plugin
 
 ### Worker Plugins


### PR DESCRIPTION
Resolves #13

Title: Make Knip and Jest workflows reusable

Summary:
- Adds `workflow_call` support to the Knip workflow while preserving existing `pull_request` and manual triggers.
- Parameterizes Bun/Yarn setup, dependency installation, Knip commands, JSON reporter command, and artifact naming so child repositories can reuse the workflow instead of copying it.
- Adds `workflow_call` support to the Jest workflow with package-manager/version inputs, install/test command overrides, summary-file handling, and checkout-depth input.
- Adds a reusable Knip reporter workflow that accepts artifact/run/PR/comment inputs while preserving the current `workflow_run` reporter behavior for this repository.
- Documents Bun and Yarn consumer examples in README.

Validation:
- `git diff --check` passed.
- Python YAML parse over workflow files passed.
- `actionlint v1.7.12` passed for `.github/workflows/knip.yml`, `.github/workflows/knip-reporter.yml`, and `.github/workflows/jest-testing.yml`.

Notes:
- Not live-tested in GitHub Actions because that requires public/account-owned workflow execution.
- No public claim, PR, comment, GitHub login, or payout action was performed by the agent.
