### PR TITLE
ci: add reusable Knip and Jest workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,81 @@
+# Reusable workflows
+
+This repository exposes Knip and Jest as reusable workflows so repositories that inherited from the template can consume one centrally maintained implementation.
+
+## Knip
+
+```yaml
+name: Knip
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  run-knip:
+    uses: ubiquity-os/plugin-template/.github/workflows/reusable-knip.yml@main
+    with:
+      package-manager: bun
+      install-command: bun install
+      knip-command: bun run knip
+      knip-json-command: bun run knip --reporter json
+```
+
+For Yarn repositories:
+
+```yaml
+jobs:
+  run-knip:
+    uses: ubiquity-os/plugin-template/.github/workflows/reusable-knip.yml@main
+    with:
+      package-manager: yarn
+      node-version: 24
+      yarn-version: "4.9.2"
+      install-command: yarn install --immutable
+      knip-command: yarn knip
+      knip-json-command: yarn knip --reporter json
+```
+
+## Jest
+
+```yaml
+name: Run Jest testing suite
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  testing:
+    uses: ubiquity-os/plugin-template/.github/workflows/reusable-jest-testing.yml@main
+    with:
+      package-manager: bun
+      install-command: bun install --frozen-lockfile
+      test-command: bun run test
+```
+
+For Yarn repositories:
+
+```yaml
+jobs:
+  testing:
+    uses: ubiquity-os/plugin-template/.github/workflows/reusable-jest-testing.yml@main
+    with:
+      package-manager: yarn
+      node-version: 24
+      yarn-version: "4.9.2"
+      install-command: yarn install --immutable
+      test-command: yarn test
+```
+
+## Inputs
+
+Both reusable workflows support:
+
+- `package-manager`: `bun`, `yarn`, `npm`, or `pnpm`.
+- `bun-version`: Bun version when using Bun.
+- `node-version`: Node.js version when using Yarn, npm, or pnpm.
+- `yarn-version`: optional Corepack Yarn version for repositories pinned to different Yarn releases.
+- command overrides for install/test/Knip execution.
+
+The wrapper workflows in this template continue to run on `pull_request` and `workflow_dispatch`, but delegate implementation to the reusable workflows.

--- a/.github/workflows/jest-testing.yml
+++ b/.github/workflows/jest-testing.yml
@@ -1,29 +1,13 @@
 name: Run Jest testing suite
+
 on:
   workflow_dispatch:
   pull_request:
 
-env:
-  NODE_ENV: "test"
-
 jobs:
   testing:
-    permissions: write-all
-    runs-on: ubuntu-latest
-    steps:
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Jest With Coverage
-        run: |
-          bun install --frozen-lockfile
-          bun run test
-
-      - name: Add Jest Report to Summary
-        if: always()
-        run: echo "$(cat test-dashboard.md)" >> $GITHUB_STEP_SUMMARY
+    uses: ./.github/workflows/reusable-jest-testing.yml
+    with:
+      package-manager: bun
+      install-command: bun install --frozen-lockfile
+      test-command: bun run test

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -6,28 +6,9 @@ on:
 
 jobs:
   run-knip:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install toolchain
-        run: bun install
-
-      - name: Store PR number
-        run: echo ${{ github.event.number }} > pr-number.txt
-
-      - name: Run Knip
-        run: bun run knip || bun run knip --reporter json > knip-results.json
-
-      - name: Upload knip result
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: knip-results
-          path: |
-            knip-results.json
-            pr-number.txt
+    uses: ./.github/workflows/reusable-knip.yml
+    with:
+      package-manager: bun
+      install-command: bun install
+      knip-command: bun run knip
+      knip-json-command: bun run knip --reporter json

--- a/.github/workflows/reusable-jest-testing.yml
+++ b/.github/workflows/reusable-jest-testing.yml
@@ -1,0 +1,109 @@
+name: Reusable Jest Testing Suite
+
+on:
+  workflow_call:
+    inputs:
+      package-manager:
+        description: "Package manager to use: bun, yarn, npm, or pnpm."
+        required: false
+        default: "bun"
+        type: string
+      bun-version:
+        description: "Bun version to install when package-manager is bun."
+        required: false
+        default: "latest"
+        type: string
+      node-version:
+        description: "Node.js version to install for yarn, npm, or pnpm."
+        required: false
+        default: "24"
+        type: string
+      yarn-version:
+        description: "Optional Yarn version activated through Corepack."
+        required: false
+        default: ""
+        type: string
+      install-command:
+        description: "Dependency installation command."
+        required: false
+        default: "bun install --frozen-lockfile"
+        type: string
+      test-command:
+        description: "Command that runs the Jest test suite."
+        required: false
+        default: "bun run test"
+        type: string
+      summary-file:
+        description: "Markdown file appended to the GitHub step summary when present."
+        required: false
+        default: "test-dashboard.md"
+        type: string
+      node-env:
+        description: "NODE_ENV value used while running the test suite."
+        required: false
+        default: "test"
+        type: string
+
+jobs:
+  testing:
+    name: Run Jest testing suite
+    runs-on: ubuntu-latest
+    permissions: write-all
+    env:
+      NODE_ENV: ${{ inputs.node-env }}
+    steps:
+      - name: Setup Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'bun'
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Setup package manager
+        if: inputs.package-manager != 'bun'
+        shell: bash
+        run: |
+          set -euo pipefail
+          corepack enable
+          case "${{ inputs.package-manager }}" in
+            yarn)
+              if [ -n "${{ inputs.yarn-version }}" ]; then
+                corepack prepare "yarn@${{ inputs.yarn-version }}" --activate
+              fi
+              ;;
+            pnpm)
+              corepack prepare pnpm@latest --activate
+              ;;
+            npm)
+              ;;
+            *)
+              echo "Unsupported package-manager: ${{ inputs.package-manager }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Jest with coverage
+        run: |
+          ${{ inputs.install-command }}
+          ${{ inputs.test-command }}
+
+      - name: Add Jest report to summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f "${{ inputs.summary-file }}" ]; then
+            cat "${{ inputs.summary-file }}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No Jest dashboard found at ${{ inputs.summary-file }}" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/reusable-knip.yml
+++ b/.github/workflows/reusable-knip.yml
@@ -1,0 +1,117 @@
+name: Reusable Knip
+
+on:
+  workflow_call:
+    inputs:
+      package-manager:
+        description: "Package manager to use: bun, yarn, npm, or pnpm."
+        required: false
+        default: "bun"
+        type: string
+      bun-version:
+        description: "Bun version to install when package-manager is bun."
+        required: false
+        default: "latest"
+        type: string
+      node-version:
+        description: "Node.js version to install for yarn, npm, or pnpm."
+        required: false
+        default: "24"
+        type: string
+      yarn-version:
+        description: "Optional Yarn version activated through Corepack."
+        required: false
+        default: ""
+        type: string
+      install-command:
+        description: "Dependency installation command."
+        required: false
+        default: "bun install"
+        type: string
+      knip-command:
+        description: "Command used for the human-readable Knip run."
+        required: false
+        default: "bun run knip"
+        type: string
+      knip-json-command:
+        description: "Command used to produce the JSON artifact when Knip fails."
+        required: false
+        default: "bun run knip --reporter json"
+        type: string
+      artifact-name:
+        description: "Name of the uploaded artifact containing Knip results."
+        required: false
+        default: "knip-results"
+        type: string
+      upload-artifact:
+        description: "Whether to upload knip-results.json and pr-number.txt on failure."
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  run-knip:
+    name: Run Knip
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'bun'
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Setup package manager
+        if: inputs.package-manager != 'bun'
+        shell: bash
+        run: |
+          set -euo pipefail
+          corepack enable
+          case "${{ inputs.package-manager }}" in
+            yarn)
+              if [ -n "${{ inputs.yarn-version }}" ]; then
+                corepack prepare "yarn@${{ inputs.yarn-version }}" --activate
+              fi
+              ;;
+            pnpm)
+              corepack prepare pnpm@latest --activate
+              ;;
+            npm)
+              ;;
+            *)
+              echo "Unsupported package-manager: ${{ inputs.package-manager }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Install toolchain
+        run: ${{ inputs.install-command }}
+
+      - name: Store PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.number }}" > pr-number.txt
+
+      - name: Run Knip
+        shell: bash
+        run: |
+          set -o pipefail
+          ${{ inputs.knip-command }} || ${{ inputs.knip-json-command }} > knip-results.json
+
+      - name: Upload Knip result
+        if: failure() && inputs.upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: |
+            knip-results.json
+            pr-number.txt
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Closes #13.

- Adds reusable Knip workflow exposed via `workflow_call`.
- Adds reusable Jest testing workflow exposed via `workflow_call`.
- Replaces the local Knip/Jest workflow implementations with thin wrappers that call the reusable workflows.
- Documents Bun and Yarn consumer examples for repositories that inherited from this template.

## Implementation notes

The reusable workflows support the differences called out in the issue:

- `package-manager`: `bun`, `yarn`, `npm`, or `pnpm`.
- `bun-version` for Bun repositories.
- `node-version` and optional `yarn-version` for Yarn repositories with different pinned versions.
- Overrideable install, test, Knip, and Knip JSON reporter commands.

## Test plan

- [x] Parsed all `.github/workflows/*.yml` files with PyYAML.
- [x] Ran `actionlint` against the changed workflow files.
- [x] Ran Prettier check on the changed workflow/docs files.
- [x] Ran `npx --yes bun install --frozen-lockfile`.
- [x] Ran `npx --yes bun run knip`.
- [x] Ran `npx --yes bun run test` — 5 tests passed.
